### PR TITLE
Update and correct several URLs

### DIFF
--- a/_exts/edit_on_github.py
+++ b/_exts/edit_on_github.py
@@ -4,7 +4,7 @@ This extension makes it easy to edit documentation on GitHub. It is heavily
 inspired by the Sphinx extension of exactly the same name in the Astropy
 repository:
 
-  https://github.com/astropy/astropy/blob/master/astropy/sphinx/ext/edit_on_github.py
+  https://github.com/astropy/astropy-helpers/blob/master/astropy_helpers/sphinx/ext/edit_on_github.py
 
 It adds a field to the page template context called ``edit_on_github`` which
 can be used to link to the GitHub edit page.

--- a/guides/google-analytics/index.rst
+++ b/guides/google-analytics/index.rst
@@ -20,7 +20,7 @@ done with the following steps.
    listing of the accounts your login has access to. Within this table
    click on "Create a new property". This should be at the bottom of the list.
 #. Enter the website name (e.g. Open Development Toolkit) and website URL
-   (e.g. http://opendevelopmenttoolkit.net). Change the Reporting Time Zone to
+   (e.g. http://opendevtoolkit.net). Change the Reporting Time Zone to
    United Kingdom and select "GMT (no daylight saving)".
 #. Click on "Get Tracking ID". This will get you to a page where the tracking
    ID will be prominently displayed.

--- a/sysadmin/backup.rst
+++ b/sysadmin/backup.rst
@@ -87,7 +87,7 @@ Appendix: Backup issues
    Bytemark managed), or at least not at the same provider.
 -  Linode: snapshots might be too few. Linode's backup system does work
    on the fs layer, not on the block layer which makes it `pretty
-   limited <http://library.linode.com/linode-platform/backups/#limitations>`__.
+   limited <https://www.linode.com/docs/platform/backup-service#limitations>`__.
 -  Amazon EC2:
 
    -  Some EC2 servers are running off instance-store and have no
@@ -150,7 +150,7 @@ Appendix: Linode snapshots
 --------------------------
 
 Note: Beware of Linode's `backup
-restrictions <http://library.linode.com/linode-platform/backups/#limitations>`__.
+restrictions <https://www.linode.com/docs/platform/backup-service#limitations>`__.
 OK, this is how it works (as of 2011-03-25):
 
 -  Log into https://manager.linode.com/

--- a/sysadmin/overview.rst
+++ b/sysadmin/overview.rst
@@ -26,7 +26,7 @@ by our Ansible configuration management system.
 Please refer to the `Ansible inventory`_ for the canonical list of managed
 hosts and their whereabouts.
 
-.. _Ansible inventory: https://github.com/okfn/infra/blob/master/inventory/hosts
+.. _Ansible inventory: https://github.com/okfn/infra/blob/master/ansible/inventory/hosts
 
 Mailing lists
 ~~~~~~~~~~~~~

--- a/sysadmin/services/monitoring.rst
+++ b/sysadmin/services/monitoring.rst
@@ -78,8 +78,8 @@ Our current Dashboards
 .. _graphite: http://graphite.wikidot.com/
 .. _collectd: http://collectd.org
 .. _OKF infra repo: https://github.com/okfn/infra/tree/master/ansible/roles
-.. _check\_mk-server: https://github.com/okfn/infra/tree/master/ansible/roles/check_mk-server
-.. _nagios-server: https://github.com/okfn/infra/tree/master/ansible/roles/check_mk-server
+.. _check-mk-server: https://github.com/okfn/infra/tree/master/ansible/roles/check-mk-server
+.. _nagios-server: https://github.com/okfn/infra/tree/master/ansible/roles/check-mk-server
 .. _inventory: https://github.com/okfn/infra/tree/master/ansible/inventory
 .. _vars: https://github.com/okfn/infra/tree/master/ansible/inventory/host_vars
 .. _graphite.okfn.org: http://graphite.okfn.org/


### PR DESCRIPTION
I ran into a [bad link](https://github.com/okfn/infra/blob/master/inventory/hosts) while looking through your documentation and decided to check for others while I was correcting it.

On a related note, there are a few links to https://ops.okfn.org/, which throws a certificate error, being that it's served by readthedocs.org. Perhaps that subdomain should serve an HTTP redirect to https://ops-manual.readthedocs.org/ instead of being a CNAME for ops-manual.readthedocs.org?

There are also numerous references to a `manage.py`, which seems to be obsolete circa okfn/infra@b017fa69.