### PR TITLE
Use HTTP for ops.okfn.org instead of HTTPS, per comment on #24

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 README
 ======
 
-Go `here <https://ops.okfn.org/>`_
+Go `here <http://ops.okfn.org/>`_
 
 Playing with this locally, you probably want to use ``make``::
 

--- a/opsmanual-getting-started.rst
+++ b/opsmanual-getting-started.rst
@@ -112,5 +112,5 @@ building the site.
 The build artefacts (a static HTML website) are copied into the ``gh-pages``
 branch of the git repository and pushed to GitHub. The manual is then served at:
 
-    https://ops.okfn.org/
+    http://ops.okfn.org/
 


### PR DESCRIPTION
Looks like these are the only two instances of HTTPS links to ops.okfn.org